### PR TITLE
fix: implement workaround for root privilege issues on macOS

### DIFF
--- a/.github/workflows/builditmac.yaml
+++ b/.github/workflows/builditmac.yaml
@@ -25,7 +25,7 @@ jobs:
         cp dist/SOURCE.URL cslol-manager-macos/
         cp build/cslol-tools/wad-* cslol-manager-macos/
         cp -R build/cslol-manager.app cslol-manager-macos/
-        cp build/cslol-manager-elevation cslol-manager-macos/cslol-manager.app/Contents/MacOS/
+        cp build/cslol-manager-elevate cslol-manager-macos/cslol-manager.app/Contents/MacOS/
         mkdir cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         cp build/cslol-tools/mod-tools cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         tar caf cslol-manager-macos.tar.xz cslol-manager-macos/

--- a/.github/workflows/builditmac.yaml
+++ b/.github/workflows/builditmac.yaml
@@ -25,6 +25,7 @@ jobs:
         cp dist/SOURCE.URL cslol-manager-macos/
         cp build/cslol-tools/wad-* cslol-manager-macos/
         cp -R build/cslol-manager.app cslol-manager-macos/
+        cp build/cslol-manager-elevation cslol-manager-macos/cslol-manager.app/Contents/MacOS/
         mkdir cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         cp build/cslol-tools/mod-tools cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         tar caf cslol-manager-macos.tar.xz cslol-manager-macos/

--- a/.github/workflows/builditmac.yaml
+++ b/.github/workflows/builditmac.yaml
@@ -26,6 +26,8 @@ jobs:
         cp build/cslol-tools/wad-* cslol-manager-macos/
         cp -R build/cslol-manager.app cslol-manager-macos/
         cp build/cslol-manager-elevate cslol-manager-macos/cslol-manager.app/Contents/MacOS/
+        plutil -replace CFBundleExecutable -string cslol-manager-elevate cslol-manager-macos/cslol-manager.app/Contents/Info.plist
+        plutil -replace CFBundleName -string cslol-manager-elevate cslol-manager-macos/cslol-manager.app/Contents/Info.plist
         mkdir cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         cp build/cslol-tools/mod-tools cslol-manager-macos/cslol-manager.app/Contents/MacOS/cslol-tools
         tar caf cslol-manager-macos.tar.xz cslol-manager-macos/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(cslol-manager LANGUAGES CXX)
+project(cslol-manager LANGUAGES CXX C)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOUIC ON)
@@ -50,6 +52,9 @@ elseif(APPLE)
     add_executable(cslol-manager MACOSX_BUNDLE
         src/main.cpp
         src/res/icon.icns
+        )
+    add_executable(cslol-manager-elevate
+        src/main_elevate.c
         )
     set_target_properties(cslol-manager
         PROPERTIES

--- a/src/main_elevate.c
+++ b/src/main_elevate.c
@@ -7,7 +7,7 @@
 #include <limits.h>
 #include <libgen.h>
 
-int main(int argc, char *argv[])
+int main()
 {
     char pathBuff[PATH_MAX];
     uint32_t buffSize = PATH_MAX;

--- a/src/main_elevate.c
+++ b/src/main_elevate.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <libgen.h>
+
+int main(int argc, char *argv[])
+{
+    char pathBuff[PATH_MAX];
+    uint32_t buffSize = PATH_MAX;
+
+    //
+    //  Find the absolute path
+    //  of this executable.
+    //
+    if (_NSGetExecutablePath(pathBuff, &buffSize) != KERN_SUCCESS)
+        return -1;
+
+    //
+    //  Remove the file component of the abs. path.
+    //
+    char *parentDir = dirname(pathBuff);
+
+    char *str;
+    int len = snprintf(
+        NULL, 
+        0, 
+        "do shell script \"sudo %s/cslol-manager >/dev/null 2>&1 &\""
+        " with prompt \"CSLOL-Manager needs administrator privileges to restart.\""
+        " with administrator privileges"
+        " without altering line endings",
+        parentDir
+    );
+
+    //
+    //  Something went wrong trying
+    //  to obtain the necessary length of the string.
+    //
+    if (len <= 0)
+        return 1;
+
+    str = (char *)malloc(len + 1);
+
+    snprintf(
+        str, 
+        len + 1,
+        "do shell script \"sudo %s/cslol-manager >/dev/null 2>&1 &\""
+        " with prompt \"CSLOL-Manager needs administrator privileges to restart.\""
+        " with administrator privileges"
+        " without altering line endings",
+        parentDir
+    );
+
+    int code = execlp (
+        "osascript",
+        "osascript",
+        "-e",
+        str,
+        NULL);
+
+    free(str);
+
+    return code;
+}

--- a/src/main_elevate.c
+++ b/src/main_elevate.c
@@ -7,6 +7,8 @@
 #include <limits.h>
 #include <libgen.h>
 
+#define COMMAND_CHAR_COUNT_MAX  1000 + PATH_MAX
+
 int main()
 {
     char pathBuff[PATH_MAX];
@@ -24,7 +26,8 @@ int main()
     //
     char *parentDir = dirname(pathBuff);
 
-    char *str;
+    char str[COMMAND_CHAR_COUNT_MAX];
+
     int len = snprintf(
         NULL, 
         0, 
@@ -42,8 +45,6 @@ int main()
     if (len <= 0)
         return 1;
 
-    str = (char *)malloc(len + 1);
-
     snprintf(
         str, 
         len + 1,
@@ -60,8 +61,6 @@ int main()
         "-e",
         str,
         NULL);
-
-    free(str);
 
     return code;
 }

--- a/src/res/MacOSXBundleInfo.plist.in
+++ b/src/res/MacOSXBundleInfo.plist.in
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleName</key>
-	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/res/MacOSXBundleInfo.plist.in
+++ b/src/res/MacOSXBundleInfo.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>cslol-manager-elevate</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleGetInfoString</key>
 	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
 	<key>CFBundleIconFile</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleName</key>
-	<string>cslol-manager-elevate</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/res/MacOSXBundleInfo.plist.in
+++ b/src/res/MacOSXBundleInfo.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<string>cslol-manager-elevate</string>
 	<key>CFBundleGetInfoString</key>
 	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
 	<key>CFBundleIconFile</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleName</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<string>cslol-manager-elevate</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Before, users were expected to manually launch the binary contained inside of the app bundle with `sudo`.

This PR proposes an implementation, written in C, which explicitly asks for the user to input their password in order for the application to restart itself with root privileges. It manually overloads the `CFBundleExecutable` and `CFBundleName` identifiers inside of the bundle manifest to point to the compiled binary of this elevation fix.

Special thanks to @dhinakg for helping me debug a syntactical issue for `osascript -e`.